### PR TITLE
small fix

### DIFF
--- a/src/listopia.lisp
+++ b/src/listopia.lisp
@@ -446,4 +446,4 @@
   (apply #'.zip-with (cons #'list lists)))
 
 (defun .unzip (lists)
-  (apply '.zip lists))
+  (apply #'.zip lists))


### PR DESCRIPTION
I fixed `.unzip` function.
It was syntactically correct, but imitated other codes.
